### PR TITLE
Build failure with GHC 8.8 and up (fail removed from Monad)

### DIFF
--- a/atp-haskell.cabal
+++ b/atp-haskell.cabal
@@ -25,7 +25,7 @@ Library
   Default-Language: Haskell2010
   Build-Depends:
     applicative-extras,
-    base >= 4.8 && < 5,
+    base >= 4.8 && < 4.13,
     containers,
     extra,
     HUnit,

--- a/atp-haskell.cabal
+++ b/atp-haskell.cabal
@@ -1,5 +1,5 @@
 Name:             atp-haskell
-Version:          1.14.1
+Version:          1.14.2
 Synopsis:         Translation from Ocaml to Haskell of John Harrison's ATP code
 Description:      This package is a liberal translation from OCaml to Haskell of
                   the automated theorem prover written in OCaml in

--- a/atp-haskell.cabal
+++ b/atp-haskell.cabal
@@ -25,7 +25,7 @@ Library
   Default-Language: Haskell2010
   Build-Depends:
     applicative-extras,
-    base >= 4.8 && < 4.13,
+    base >= 4.8 && < 5,
     containers,
     extra,
     HUnit,

--- a/src/Data/Logic/ATP/Lib.hs
+++ b/src/Data/Logic/ATP/Lib.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -56,6 +57,9 @@ module Data.Logic.ATP.Lib
 
 import Control.Applicative.Error (Failing(..))
 import Control.Concurrent (forkIO, killThread, newEmptyMVar, putMVar, takeMVar, threadDelay)
+#if MIN_VERSION_base(4,9,0)
+import qualified Control.Monad.Fail as Fail
+#endif
 import Control.Monad.RWS (evalRWS, runRWS, RWS)
 import Data.Data (Data)
 import Data.Foldable as Foldable
@@ -92,7 +96,14 @@ instance Monad Failing where
       case m of
         (Failure errs) -> (Failure errs)
         (Success a) -> f a
+#if !MIN_VERSION_base(4,13,0)
   fail errMsg = Failure [errMsg]
+#endif
+
+#if MIN_VERSION_base(4,9,0)
+instance Fail.MonadFail Failing where
+  fail errMsg = Failure [errMsg]
+#endif
 
 deriving instance Typeable Failing
 deriving instance Data a => Data (Failing a)

--- a/src/Data/Logic/ATP/Term.hs
+++ b/src/Data/Logic/ATP/Term.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE UndecidableInstances #-}
 


### PR DESCRIPTION
Build failure with GHC 8.8 and up (fail removed from Monad).
See failing build at: https://hackage.haskell.org/package/atp-haskell-1.14.1/reports/2

Restrict to `base < 4.13`.

On hackage:
2024-03-13T22:10:58Z  	AndreasAbel	  [atp-haskell-1.9-r1](https://hackage.haskell.org/package/atp-haskell-1.9/revisions)
2024-03-13T22:10:58Z  	AndreasAbel	  [atp-haskell-1.8-r1](https://hackage.haskell.org/package/atp-haskell-1.8/revisions)
2024-03-13T22:10:57Z  	AndreasAbel	  [atp-haskell-1.7-r1](https://hackage.haskell.org/package/atp-haskell-1.7/revisions)
2024-03-13T22:10:57Z  	AndreasAbel	  [atp-haskell-1.14-r1](https://hackage.haskell.org/package/atp-haskell-1.14/revisions)
2024-03-13T22:10:57Z  	AndreasAbel	  [atp-haskell-1.14.1-r1](https://hackage.haskell.org/package/atp-haskell-1.14.1/revisions)
2024-03-13T22:10:56Z  	AndreasAbel	  [atp-haskell-1.13-r1](https://hackage.haskell.org/package/atp-haskell-1.13/revisions)
2024-03-13T22:10:56Z  	AndreasAbel	  [atp-haskell-1.10-r1](https://hackage.haskell.org/package/atp-haskell-1.10/revisions)